### PR TITLE
5 requests per every 70 seconds, instead of 45 requests every 60

### DIFF
--- a/src/itemsmanagerworker.h
+++ b/src/itemsmanagerworker.h
@@ -36,8 +36,8 @@ class QTimer;
 class BuyoutManager;
 class TabCache;
 
-const int kThrottleRequests = 45;
-const int kThrottleSleep = 60;
+const int kThrottleRequests = 5;
+const int kThrottleSleep = 70;
 const int kMaxCacheSize = (1000*1024*1024); // 1GB
 
 struct ItemsRequest {


### PR DESCRIPTION
Since GGG introduce aggressive throttling, as a temp solution maybe this can be limited to 5 tabs checked every 70 seconds.

Better would be a dialog window to change both the number of tabs checked AND the time between each check